### PR TITLE
Fix domain vulnerability

### DIFF
--- a/api/store.js
+++ b/api/store.js
@@ -37,12 +37,17 @@ class HttpError extends Error {
 }
 
 async function validate(longUrl) {
-  let host;
+  let parsed;
   debugLog(`validating longUrl ${longUrl}`);
   try {
-    ({ host } = url.parse(longUrl));
+    parsed = url.parse(longUrl);
   } catch (ex) {
     throw new HttpError(400, 'Not a valid URL');
+  }
+  const { host, path } = parsed;
+  if (path.charAt(0) !== '/') {
+    // Disallow anything with a doctored path
+    throw new HttpError(400, 'Not a valid URL for shortening');
   }
   const suffixMatcher = suffix => suffix === host || endsWith(host, `.${suffix}`);
   if (!find(domainSafeList, suffixMatcher)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@change-org/longlinks",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@change-org/longlinks",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A serverless URL shortener that leverages Amazon Lambda for short link creation, and S3 for link storage and redirection.",
   "author": "Change Engineering",
   "license": "MIT",

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -127,6 +127,11 @@ describe('When the `url` property', () => {
   );
 
   test(
+    'even more sneakily prepends the allowed domain to a malicious domain with an encoded character',
+    () => expectStatusForUrl('https://www.domain1.com%2Eevil.com?foo=bar', 400)
+  );
+
+  test(
     'contains an allowed domain string, but in the path. Nice try but still 400',
     () => expectStatusForUrl('https://www.evil.com/https://www.domain1.com', 400)
   );


### PR DESCRIPTION
Fix a vulnerability in the hostname checking logic, which was allowing a doctored hostname containing encoded characters to pass the validation and thus allowed shortening of links that were not strictly within the allowed set of domains.