### PR TITLE
Update node runtime to suggested nodejs12.x, to fix failed deploy on nodejs8.10

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: change-longlinks
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   endpointType: ${file(config.json):api_endpoint_type}
   stage: ${file(config.json):stage}
   region: ${file(config.json):region}


### PR DESCRIPTION
Fixes unsupported nodejs version failure on fresh `serverless deploy`.

> The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs12.x) while creating or updating functions.