### PR TITLE
Add dependabot.yml with daily updates schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
This should enable Dependabot opening PRs for non-security dependency updates.